### PR TITLE
KIRORU_APP_TEAM-165 [メンテ] RecyclerView.AdapterのsetOnClickListener

### DIFF
--- a/app/src/main/java/jp/kiroru/kotlinlesson02/CustomAdapter.kt
+++ b/app/src/main/java/jp/kiroru/kotlinlesson02/CustomAdapter.kt
@@ -5,16 +5,15 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import jp.kiroru.kotlinlesson02.databinding.CellMainBinding
 
-class CustomAdapter(private val items: List<Item>, private val listener: ItemSelectionListener): RecyclerView.Adapter<CustomAdapter.ViewHolder>() {
+class CustomAdapter(
+    private val items: List<Item>,
+    private val listener: ItemSelectionListener
+    ): RecyclerView.Adapter<CustomAdapter.ViewHolder>() {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
 
         val binding = CellMainBinding.inflate(LayoutInflater.from(parent.context), parent, false)
-        return ViewHolder(binding).apply {
-            binding.root.setOnClickListener {
-                listener.notifyItemSelected(items[adapterPosition])
-            }
-        }
+        return ViewHolder(binding, items, listener)
     }
 
     override fun getItemCount() = items.size
@@ -25,9 +24,21 @@ class CustomAdapter(private val items: List<Item>, private val listener: ItemSel
         holder.cellDescription.text = item.description
     }
 
-    class ViewHolder(binding: CellMainBinding) : RecyclerView.ViewHolder(binding.root) {
+    class ViewHolder(
+        binding: CellMainBinding,
+        private val items: List<Item>,
+        private val listener: ItemSelectionListener
+        ) : RecyclerView.ViewHolder(binding.root) {
+
         val cellTitle = binding.cellTitle
         val cellDescription = binding.cellDescription
+        init {
+            binding.root.setOnClickListener {
+                items[adapterPosition].let {
+                    listener.notifyItemSelected(items[adapterPosition])
+                }
+            }
+        }
     }
 
     interface ItemSelectionListener {


### PR DESCRIPTION
### チケット

https://kiroru.backlog.com/view/KIRORU_APP_TEAM-165

### 改修内容

- ViewHolderのinitでlistenerを設定

### チェックリスト

- [x] リストが表示されること
- [x] スクロールしても表示内容にずれがないこと
- [x] スクロールしてタップしても視覚的にタップしたものと遷移した先の情報が一致していること（６をタップしたら遷移先に６の情報が表示されていること）
